### PR TITLE
fix: total computation of exactly rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function randomPassword(opts) {
 
   var allExactly = characterRules.every(function (rule) { return rule.exactly });
   if (allExactly) {
-    var exactlyLength = characterRules.reduce(function (l, r) { return l.exactly + r.exactly }, 0);
+    var exactlyLength = characterRules.reduce(function (acc, r) { return acc + r.exactly }, 0);
     if (exactlyLength !== opts.length) {
       throw new Error('Must pass a set without exactly rule to generate the specified length');
     }

--- a/index.spec.js
+++ b/index.spec.js
@@ -193,6 +193,23 @@ describe('passwordGenerator', () => {
         ]
       })).toThrow('Must pass a set without exactly rule to generate the specified length');
     });
+
+    it('accepts a totaled number of exactly character sets + required sets', () => {
+      expect(() => randomPassword({
+        length: 10,
+        characters: [
+          { characters: '123', exactly: 10 }
+        ]
+      })).not.toThrow();
+
+      expect(() => randomPassword({
+        length: 30,
+        characters: [
+          { characters: '123', exactly: 10 },
+          { characters: '123', exactly: 20 }
+        ]
+      })).not.toThrow();
+    });
   });
 
   describe('avoidAmbiguous option', () => {


### PR DESCRIPTION
This PR introduces a fix in the way the total number of `exactly` characters set in rules are specified. It also adds a unit test to ensure this won't break anymore in the future.

I believe the current implementation has a bug in the use of the `callback` parameter of the `Array.reduce` method, which has a [signature](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce#parameters) of `(accumulator, currentValue, [index], [array])`.

Thank you for providing this module 👍 