### PR TITLE
Added type declarations for ESM support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+export function randomPassword(opts: any): any;
+export function randomString(opts: any): any;
+export * from "./lib/character-sets";
+//# sourceMappingURL=index.d.ts.map

--- a/index.d.ts.map
+++ b/index.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.js"],"names":[],"mappings":"AAeA,+CAuDC;AAqDD,6CAUC"}

--- a/lib/character-sets.d.ts
+++ b/lib/character-sets.d.ts
@@ -1,0 +1,9 @@
+export var lower: string;
+export var upper: string;
+export var consonants: string;
+export var vowels: string;
+export var digits: string;
+export var symbols: string;
+export var fullSymbols: string;
+export var copyableSymbols: string;
+//# sourceMappingURL=character-sets.d.ts.map

--- a/lib/character-sets.d.ts.map
+++ b/lib/character-sets.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"character-sets.d.ts","sourceRoot":"","sources":["character-sets.js"],"names":[],"mappings":""}

--- a/lib/random.d.ts
+++ b/lib/random.d.ts
@@ -1,0 +1,12 @@
+declare var _default: Random;
+export default _default;
+export function Random(randomSource: any): void;
+export class Random {
+    constructor(randomSource: any);
+    _randomSource: any;
+    choose(choices: any): any;
+    getInt(upperBoundExclusive: any): number;
+    _getInt(upperBoundExclusive: any): number;
+    shuffle(items: any): any[];
+}
+//# sourceMappingURL=random.d.ts.map

--- a/lib/random.d.ts.map
+++ b/lib/random.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"random.d.ts","sourceRoot":"","sources":["random.js"],"names":[],"mappings":";;AAMA,gDAKC;;IALD,+BAKC;IADC,mBAAiC;IAGnC,0BAMC;IAED,yCAYC;IAED,0CAaC;IAED,2BAOC"}

--- a/lib/util.d.ts
+++ b/lib/util.d.ts
@@ -1,0 +1,8 @@
+export function assign(...args: any[]): any;
+export function intersection(left: any, right: any): string[];
+export function isInteger(n: any): boolean;
+export function isString(s: any): boolean;
+export function range(n: any): any;
+export function repeat(val: any, n: any): any;
+export function toArray(x: any): any;
+//# sourceMappingURL=util.d.ts.map

--- a/lib/util.d.ts.map
+++ b/lib/util.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"util.d.ts","sourceRoot":"","sources":["util.js"],"names":[],"mappings":"AAEA,4CAcC;AAID,8DAgBC;AAID,2CAEC;AAID,0CAEC;AAID,mCAEC;AAID,8CAEC;AAID,qCAEC"}


### PR DESCRIPTION
Type declaration generation process:

1. Install TypeScript
`>npm i typescript --save-dev`

2. Create tsconfig.json
```
{
  "include": ["index.js", "lib/*.js"],
  "compilerOptions": {
    "allowJs": true,
    "declaration": true,
    "emitDeclarationOnly": true,
    "declarationMap": true
  }
}
```

3. Produce type files
`>tsc --build `

4. Edit index.d.ts, adding the following as the last export
`export * from "./lib/character-sets";`


Tested by using in a project, building and running on NodeJS